### PR TITLE
Fix big-endian int32 decoding for large offsets

### DIFF
--- a/src/abif.nim
+++ b/src/abif.nim
@@ -103,10 +103,14 @@ proc readInt32BE(s: Stream): int =
   var val: uint32 = s.readUint32()
   var res: uint32
   bigEndian32(addr res, addr val)
-  result = cast[int32](res).int
-  # Adjust for negative values
-  if result > 2147483647:
-    result -= 4294967296.int
+
+  when sizeof(int) >= sizeof(uint32):
+    result = res.int
+  else:
+    if res <= uint32(high(int)):
+      result = res.int
+    else:
+      raise newException(OverflowDefect, "32-bit value exceeds Nim int range")
 
 proc readStringBE(s: Stream, len: int): string =
   ## Reads a string of specified length from the stream.

--- a/tests/test_abif.nim
+++ b/tests/test_abif.nim
@@ -1,5 +1,6 @@
 import unittest
 import strutils, os, streams
+import std/tables
 import ../src/abif
 
 proc runTests() =

--- a/tests/test_abif.nim
+++ b/tests/test_abif.nim
@@ -70,19 +70,74 @@ proc runTests() =
     test "Test getTagNames function":
       let trace = newABIFTrace("tests/3730.ab1")
       let tagNames = trace.getTagNames()
-      
+
       # Should have at least a few tags
       check tagNames.len > 0
-      
+
       # Check for commonly expected tags
       var hasBaseTags = false
       for tag in tagNames:
         if tag.startsWith("PBAS") or tag.startsWith("DATA"):
           hasBaseTags = true
           break
-      
+
       check hasBaseTags
       trace.close()
+
+    test "Large directory offsets remain positive":
+      proc setUint16BE(data: var string, pos: int, value: uint16) =
+        data[pos] = chr(int(value shr 8))
+        data[pos + 1] = chr(int(value and 0x00FF'u16))
+
+      proc setUint32BE(data: var string, pos: int, value: uint32) =
+        data[pos] = chr(int((value shr 24) and 0xFF'u32))
+        data[pos + 1] = chr(int((value shr 16) and 0xFF'u32))
+        data[pos + 2] = chr(int((value shr 8) and 0xFF'u32))
+        data[pos + 3] = chr(int(value and 0xFF'u32))
+
+      let tmpFile = "tests/tmp_large_offset.ab1"
+      var contents = newString(64)
+      for i in 0..<contents.len:
+        contents[i] = '\0'
+
+      contents[0] = 'A'
+      contents[1] = 'B'
+      contents[2] = 'I'
+      contents[3] = 'F'
+
+      setUint16BE(contents, 4, 1)
+      setUint32BE(contents, 18, 1)
+      setUint32BE(contents, 26, 32)
+
+      let dirPos = 32
+      contents[dirPos] = 'T'
+      contents[dirPos + 1] = 'E'
+      contents[dirPos + 2] = 'S'
+      contents[dirPos + 3] = 'T'
+      setUint32BE(contents, dirPos + 4, 1)
+      setUint16BE(contents, dirPos + 8, uint16(ord(etLong)))
+      setUint16BE(contents, dirPos + 10, 4)
+      setUint32BE(contents, dirPos + 12, 2)
+      setUint32BE(contents, dirPos + 16, 8)
+      let largeOffset = 0x80000000'u32
+      setUint32BE(contents, dirPos + 20, largeOffset)
+      setUint32BE(contents, dirPos + 24, 0)
+
+      writeFile(tmpFile, contents)
+
+      var trace: ABIFTrace = nil
+      try:
+        trace = newABIFTrace(tmpFile)
+        check trace.tags.hasKey("TEST1")
+        let entry = trace.tags["TEST1"]
+        check entry.dataOffset == int(largeOffset)
+      finally:
+        if trace != nil:
+          trace.close()
+        try:
+          removeFile(tmpFile)
+        except CatchableError:
+          discard
 
 when isMainModule:
   runTests()


### PR DESCRIPTION
## Summary
- update the big-endian 32-bit reader to return unsigned-sized values on 64-bit Nim and guard overflows on smaller platforms
- add a regression test that crafts a minimal ABIF directory with a large offset to ensure the decoded value remains positive

## Testing
- nimble test *(fails: nimble not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_b_68fde2cf0ef48330a0d2e597a785c184